### PR TITLE
Reorganised config file and location of site/met data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ We provide two possible routes to obtaining these data:
 The advantage of the first approach is it is free to use, and you could explore the use of different grids, etc. The second approach is much faster as all of the processing can be done in parallel (hours versus weeks to download) and requires orders of magnitude less storage space, since only the required fields are extracted in the cloud. However, it uses GCP credits (~$100 to extract ~40 years of data at 9 sites). The zarr store could also be accessed from an external server, but processing would likely be substantially slower (not tested in earnest).
 
 
+### Observational data
+
+Currently, will only read in AGAGE data files. These can be provided as a zip archive of the type that can be downloaded from the AGAGE website.
+
+
 ## Developer notes
 
 To install an editable version of this package in your environment, go to the root directory of this repo and type:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,48 @@ A machine learning library for the estimation of greenhouse gas baseline timeser
 
 ## Setup
 
+### File structure
+
+This repository is structured as follows:
+
+```
+data/ # data files required to run the code
+   ├── intem_baselines.zip  # baseline flags from InTEM
+   ├── site_info.json # Site information (location, validation/testing periods, etc.)
+   └── met_info.json # Meteorological variable information (variable names, levels, etc.)
+docker/ # dockerfiles for extracting meteorlogical fields from ERA-5 on GCP in a container
+ml_baselines/   # main package
+├── met_retrieve/
+├── models/
+├── data/
+└── config.json # untracked config file for specifying paths
+models/ # trained models and features
+└── features/ # extracted features for training/testing
+notebooks/ # Jupyter notebooks for experimentation and visualization
+tests/ # unit and integration tests
+```
+
+In addition, you must specify the location of meteorological fields and mole fraction observations.
+
+### Configuration
+
 Some configuration parameters are required to run this code. These are stored in an untracked file ```ml_baselines/config.json```. To create a template of this file, run:
 
 ```
 python ml_baselines/config.py
 ```
 
-Input the ```data_path``` and other parameters in the relevant fields.
+Example structure of ```config.json```:
+
+```
+{
+    "met_path": <path to meteorological data files>,
+    "obs_path": <path to mole fraction observation files>,
+    "model_type": "MLPClassifier",
+    "models_path": <defaults to location in repository>,
+    "met_type": "arco-era5"
+}
+```
 
 ### Meteorological fields
 

--- a/data/met_info.json
+++ b/data/met_info.json
@@ -1,0 +1,58 @@
+{
+    "sp": {
+        "file": "single_level",
+        "var_in_file": "sp",
+        "level": "",
+        "units": "hPa",
+        "long_name": "Surface Pressure"
+    },
+    "blh": {
+        "file": "single_level",
+        "var_in_file": "blh",
+        "level": "",
+        "units": "m",
+        "long_name": "Boundary Layer Height"
+    },
+    "u10": {
+        "file": "single_level",
+        "var_in_file": "u10",
+        "level": "",
+        "units": "m/s",
+        "long_name": "10m U-component of Wind"
+    },
+    "v10": {
+        "file": "single_level",
+        "var_in_file": "v10",
+        "level": "",
+        "units": "m/s",
+        "long_name": "10m V-component of Wind"
+    },
+    "u850": {
+        "file": "pressure_levels",
+        "var_in_file": "u",
+        "level": 850,
+        "units": "m/s",
+        "long_name": "850hPa U-component of Wind"
+    },
+    "v850": {
+        "file": "pressure_levels",
+        "var_in_file": "v",
+        "level": 850,
+        "units": "m/s",
+        "long_name": "850hPa V-component of Wind"
+    },
+    "u500": {
+        "file": "pressure_levels",
+        "var_in_file": "u",
+        "level": 500,
+        "units": "m/s",
+        "long_name": "500hPa U-component of Wind"
+    },
+    "v500": {
+        "file": "pressure_levels",
+        "var_in_file": "v",
+        "level": 500,
+        "units": "m/s",
+        "long_name": "500hPa V-component of Wind"
+    }
+}

--- a/data/site_info.json
+++ b/data/site_info.json
@@ -1,0 +1,65 @@
+{
+    "MHD": {
+        "name": "Mace Head, Ireland",
+        "coords": [53.3267, -9.9046],
+        "training_period": [2018, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "RPB": {
+        "name": "Ragged Point, Barbados",
+        "coords": [13.1651, -59.4321],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "CGO": {
+        "name": "Cape Grim, Australia",
+        "coords": [-40.6833, 144.6894],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "GSN": {
+        "name": "Gosan, South Korea",
+        "coords": [33.2924, 126.1616],
+        "training_period": [2009, 2013],
+        "validation_period": [2014, 2014],
+        "testing_period": [2015, 2017]
+    },
+    "JFJ": {
+        "name": "Jungfraujoch, Switzerland",
+        "coords": [46.547767, 7.985883],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "CMN": {
+        "name": "Monte Cimone, Italy",
+        "coords": [44.1932, 10.7014],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "THD": {
+        "name": "Trinidad Head, USA",
+        "coords": [41.0541, -124.151],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "ZEP": {
+        "name": "Zeppelin, Svalbard",
+        "coords": [78.9072, 11.8867],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    },
+    "SMO": {
+        "name": "Cape Matatula, American Samoa",
+        "coords": [-14.2474, -170.5644],
+        "training_period": [2014, 2018],
+        "validation_period": [2019, 2019],
+        "testing_period": [2020, 2023]
+    }
+}

--- a/ml_baselines/config.py
+++ b/ml_baselines/config.py
@@ -7,20 +7,24 @@ import json
 root_dir = Path(__file__).parent.parent
 package_dir = root_dir / "ml_baselines"
 
-
-def setup():
-    """Create a config file with default values.
-    """
-
-    # Create empty config file
-    config_path = package_dir / "config.json"
-
-    config_defaults = {
-        "data_path": "",
+config_defaults = {
+        "met_path": "",
+        "obs_path": "",
         "model_type": "MLPClassifier",
         "models_path": str(root_dir / "models"),
         "met_type": "arco-era5"
     }
+
+
+def setup():
+    """Create a config file with default values.
+
+    Default values are set, apart from met and obs paths, which the user must fill in. 
+    The config file is created at ml_baselines/config.json.
+    """
+
+    # Create empty config file
+    config_path = package_dir / "config.json"
 
     with open(config_path, "w") as f:
         json.dump(config_defaults, f, indent=4)
@@ -44,135 +48,30 @@ class Config():
         # Read user config file
         with open(package_dir / "config.json") as f:
             config_user = json.load(f)
-
-        self.data_path = config_user["data_path"]
-        self.model_type = config_user["model_type"]
-        self.models_path = config_user["models_path"]
-        self.met_type = config_user.get("met_type", "arco-era5")  # Default to "arco-era5" if not specified
-
-        if "obs_path" in config_user:
-            self.obs_path = config_user["obs_path"]
-        else:
-            self.obs_path = ""
-
-        # Site codes and names
-        self.site_dict = {
-                "MHD":"Mace Head, Ireland", 
-                "RPB":"Ragged Point, Barbados", 
-                "CGO":"Cape Grim, Australia", 
-                "GSN":"Gosan, South Korea",
-                "JFJ":"Jungfraujoch, Switzerland", 
-                "CMN":"Monte Cimone, Italy", 
-                "THD":"Trinidad Head, USA", 
-                "ZEP":"Zeppelin, Svalbard",
-                "SMO": "Cape Matatula, American Samoa"
-            }
-
-        # Site coordinates
-        self.site_coords_dict = {
-                        "MHD":[53.3267, -9.9046], 
-                        "RPB":[13.1651, -59.4321], 
-                        "CGO":[-40.6833, 144.6894], 
-                        "GSN":[33.2924, 126.1616],
-                        "JFJ":[46.547767, 7.985883], 
-                        "CMN":[44.1932, 10.7014], 
-                        "THD":[41.0541, -124.151], 
-                        "ZEP":[78.9072, 11.8867],
-                        "SMO": [-14.2474, -170.5644]
-                    }
-
-        # Time periods
-        self.training_period = {"MHD": [2018, 2018],
-                                "RPB": [2014, 2018],
-                                "CGO": [2014, 2018],
-                                "GSN": [2009, 2013],
-                                "JFJ": [2014, 2018],
-                                "CMN": [2014, 2018],
-                                "THD": [2014, 2018],
-                                "ZEP": [2014, 2018],
-                                "SMO": [2014, 2018]}
         
-        self.validation_period = {"MHD": [2019, 2019],
-                                "RPB": [2019, 2019],
-                                "CGO": [2019, 2019],
-                                "GSN": [2014, 2014],
-                                "JFJ": [2019, 2019],
-                                "CMN": [2019, 2019],
-                                "THD": [2019, 2019],
-                                "ZEP": [2019, 2019],
-                                "SMO": [2019, 2019]}
-        
-        self.testing_period = {"MHD": [2020, 2023],
-                                "RPB": [2020, 2023],
-                                "CGO": [2020, 2023],
-                                "GSN": [2015, 2017],
-                                "JFJ": [2020, 2023],
-                                "CMN": [2020, 2023],
-                                "THD": [2020, 2023],
-                                "ZEP": [2020, 2023],
-                                "SMO": [2020, 2023]}
+        for key, value in config_defaults.items():
+            if key in config_user:
+                setattr(self, key, config_user[key])
+            else:
+                setattr(self, key, value)
 
-        self.confidence_threshold = 0.8
+        # Read site info file
+        with open(root_dir / "data/site_info.json") as f:
+            site_info = json.load(f)
+
+        self.site_dict = {site_code: site_info[site_code]["name"] for site_code in site_info}
+        self.site_coords_dict = {site_code: site_info[site_code]["coords"] for site_code in site_info}
+        self.training_period = {site_code: site_info[site_code]["training_period"] for site_code in site_info}
+        self.validation_period = {site_code: site_info[site_code]["validation_period"] for site_code in site_info}
+        self.testing_period = {site_code: site_info[site_code]["testing_period"] for site_code in site_info}
 
         # Met variables to be extracted (and their order)
-        self.met_variables = {
-                "sp": {
-                    "file": "single_level",
-                    "var_in_file": "sp",
-                    "level": None,
-                    "units": "hPa",
-                    "long_name": "Surface Pressure",
-                },
-                "blh": {
-                    "file": "single_level",
-                    "var_in_file": "blh",
-                    "level": None,
-                    "units": "m",
-                    "long_name": "Boundary Layer Height",
-                },
-                "u10": {
-                    "file": "single_level",
-                    "var_in_file": "u10",
-                    "level": None,
-                    "units": "m/s",
-                    "long_name": "10m U-component of Wind",
-                },
-                "v10": {
-                    "file": "single_level",
-                    "var_in_file": "v10",
-                    "level": None,
-                    "units": "m/s",
-                    "long_name": "10m V-component of Wind",
-                },
-                "u850": {
-                    "file": "pressure_levels",
-                    "var_in_file": "u",
-                    "level": 850,
-                    "units": "m/s",
-                    "long_name": "850hPa U-component of Wind",
-                },
-                "v850": {
-                    "file": "pressure_levels",
-                    "var_in_file": "v",
-                    "level": 850,
-                    "units": "m/s",
-                    "long_name": "850hPa V-component of Wind",
-                },
-                "u500": {
-                    "file": "pressure_levels",
-                    "var_in_file": "u",
-                    "level": 500,
-                    "units": "m/s",
-                    "long_name": "500hPa U-component of Wind",
-                },
-                "v500": {
-                    "file": "pressure_levels",
-                    "var_in_file": "v",
-                    "level": 500,
-                    "units": "m/s",
-                    "long_name": "500hPa V-component of Wind",
-                },
-            }
+        with open(root_dir / "data/met_info.json") as f:
+            met_info = json.load(f)
+        self.met_variables = met_info
+
+        # TODO: remove this?
+        self.confidence_threshold = 0.8
 
         # Define the grid system (deviations in degrees from the site location)
         self.lats_grid = np.array([0, 5, 5, 0, -5, -5, -5, 0, 5, 10, 10, 0, -10, -10, -10, 0, 10])

--- a/ml_baselines/data.py
+++ b/ml_baselines/data.py
@@ -10,7 +10,6 @@ from ml_baselines.config import Config
 
 cfg = Config()
 site_coords_dict = cfg.site_coords_dict
-data_path = Path(cfg.data_path)
 package_path = cfg.package_dir
 root_path = cfg.root_dir
 

--- a/ml_baselines/features.py
+++ b/ml_baselines/features.py
@@ -10,7 +10,7 @@ from ml_baselines.utils import longitude_to_360
 
 cfg = Config()
 site_coords_dict = cfg.site_coords_dict
-met_path = Path(cfg.data_path + "/meteorological_data")
+met_path = Path(cfg.met_path)
 models_path = Path(cfg.models_path)
 
 lats_grid = cfg.lats_grid
@@ -40,8 +40,9 @@ def preprocess_features(site, year, force=False):
     """
 
     # Path to the data
-    data_path = met_path / "ECMWF" / site.upper()
+    data_path = met_path / site.upper()
 
+    # TODO: make output filename more descriptive, so we can test different feature sets
     output_filename = models_path / "features" / f"features_{site}_{year}.csv.gz"
 
     # Check if the data path exists
@@ -184,6 +185,8 @@ def preprocess_features_arco_era5(site,
     These files should have already undergone some preprocessing (see gcp_era5 container), including 
     interpolation onto a grid with +/- 5 and 10 degrees latitude and longitude
 
+    Expected filename format is era5-<site>-<year>.nc, and the files should be located in the directory specified by cfg.met_path (or input_dir if specified).
+
     Args:
         site (str): Site code.
         force (bool): If True, force reprocessing even if the file already exists.
@@ -199,7 +202,7 @@ def preprocess_features_arco_era5(site,
     if input_dir:
         data_path = Path(input_dir)
     else:
-        data_path = met_path / "arco-era5"
+        data_path = met_path
 
     files = sorted((data_path).glob(f"era5*{site.upper()}*.nc"))
 


### PR DESCRIPTION
Changes:

- Move site info and met. data info out of config script and into data folder
- Removed the "data_path" key from config.json, and replaced with ```met_path``` and ```obs_path```, to make explicit the location of these files