### PR TITLE
saving trained models and analysing gridCV scores

### DIFF
--- a/ml_baselines/modelling/cv_analysis.py
+++ b/ml_baselines/modelling/cv_analysis.py
@@ -23,7 +23,7 @@ def load_cv_results(site, save_suffix, model_type, save_path=cfg.models_path) ->
         DataFrame with all columns as-is, plus recalculated rank_test_<metric>
         columns that are global across all data_kwarg groups.
     """
-    filename = f"cv_results_{site}_{model_type}_model.csv" if save_suffix is None else f"cv_results_{site}_{model_type}_{save_suffix}.csv"
+    filename = f"cv_results_{site}_{model_type}.csv" if save_suffix is None else f"cv_results_{site}_{model_type}_{save_suffix}.csv"
     filepath = Path(save_path) / site / filename
 
     if not filepath.exists():

--- a/ml_baselines/modelling/cv_analysis.py
+++ b/ml_baselines/modelling/cv_analysis.py
@@ -1,0 +1,354 @@
+import math
+import re
+
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from ml_baselines.config import Config
+cfg = Config()
+
+def load_cv_results(site, save_suffix, model_type, save_path=cfg.models_path) -> pd.DataFrame:
+    """
+    Load a CV results CSV saved by train_baseline_model_grid_search.
+
+    Args:
+        site: Site name (e.g. "MHD").
+        save_suffix: Filename suffix used when saving (None for default name).
+        model_type: Model type string (e.g. "gradient_boosting").
+        save_path: Root models directory. Defaults to cfg.models_path.
+
+    Returns:
+        DataFrame with all columns as-is, plus recalculated rank_test_<metric>
+        columns that are global across all data_kwarg groups.
+    """
+    filename = f"cv_results_{site}_{model_type}_model.csv" if save_suffix is None else f"cv_results_{site}_{model_type}_{save_suffix}.csv"
+    filepath = Path(save_path) / site / filename
+
+    if not filepath.exists():
+        raise FileNotFoundError(f"CV results file not found: {filepath}")
+
+    df = pd.read_csv(filepath)
+    df = _rerank(df)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _rerank(df: pd.DataFrame) -> pd.DataFrame:
+    """Recalculate rank_test_<metric> globally across all data_kwarg groups."""
+    df = df.copy()
+    for metric in _detect_metrics(df):
+        score_col = f"mean_test_{metric}"
+        df[f"rank_test_{metric}"] = df[score_col].rank(ascending=False, method="min").astype(int)
+    return df
+
+
+def _detect_metrics(cv_df: pd.DataFrame) -> list[str]:
+    """Return all metric names found as mean_test_<metric> columns."""
+    return [
+        re.fullmatch(r"mean_test_(.+)", c).group(1)
+        for c in cv_df.columns
+        if re.fullmatch(r"mean_test_(.+)", c)
+    ]
+
+
+def _resolve_metric(cv_df: pd.DataFrame, metric: str | None) -> str:
+    """Resolve None to 'f1' if present, otherwise the first available metric."""
+    if metric is not None:
+        return metric
+    available = _detect_metrics(cv_df)
+    if not available:
+        raise ValueError("No mean_test_<metric> columns found in cv_df.")
+    return "f1" if "f1" in available else available[0]
+
+
+def _param_cols(cv_df: pd.DataFrame) -> list[str]:
+    return [c for c in cv_df.columns if c.startswith("param_")]
+
+
+def _score_display_name(metric: str) -> str:
+    return metric.replace("_", " ")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_best_params(cv_df: pd.DataFrame, n: int = 1, metric: str | None = None) -> pd.DataFrame:
+    """
+    Return the top n parameter sets by test score.
+
+    Args:
+        cv_df: CV results DataFrame from load_cv_results.
+        n: Number of top parameter sets to return.
+        metric: Metric to rank by (e.g. "f1", "precision", "recall").
+            Defaults to "f1" if present, otherwise the first available metric.
+
+    Returns:
+        DataFrame with param_* columns plus test score, train score, and rank,
+        sorted best-first.
+    """
+    metric = _resolve_metric(cv_df, metric)
+    score_col = f"mean_test_{metric}"
+    keep_cols = _param_cols(cv_df) + [score_col, f"mean_train_{metric}", f"rank_test_{metric}"]
+    keep_cols = [c for c in keep_cols if c in cv_df.columns]
+    return cv_df[keep_cols].sort_values(score_col, ascending=False).head(n).reset_index(drop=True)
+
+
+def get_top_params(
+    cv_df: pd.DataFrame,
+    threshold: float | None = None,
+    n: int = 5,
+    metric: str | None = None,
+) -> pd.DataFrame:
+    """
+    Return parameter sets that meet a score threshold, or the top n if no
+    threshold is given.
+
+    Args:
+        cv_df: CV results DataFrame from load_cv_results.
+        threshold: Minimum score value. If provided, returns all rows that meet
+            or exceed this value, ignoring n.
+        n: Number of top rows to return when no threshold is given.
+        metric: Metric to filter/sort by. Defaults to "f1" if present,
+            otherwise the first available metric.
+
+    Returns:
+        Filtered and sorted DataFrame (best-first) with param_* columns,
+        test score, train score, and rank columns.
+    """
+    metric = _resolve_metric(cv_df, metric)
+    score_col = f"mean_test_{metric}"
+    keep_cols = _param_cols(cv_df) + [score_col, f"mean_train_{metric}", f"rank_test_{metric}"]
+    keep_cols = [c for c in keep_cols if c in cv_df.columns]
+    df = cv_df[keep_cols].sort_values(score_col, ascending=False)
+    if threshold is not None:
+        return df[df[score_col] >= threshold].reset_index(drop=True)
+    return df.head(n).reset_index(drop=True)
+
+
+def summarise_param_effects(
+    cv_df: pd.DataFrame, metric: str | None = None
+) -> dict[str, pd.DataFrame]:
+    """
+    For each param_* column, compute mean, std, and count of the test score
+    grouped by that parameter's values.
+
+    Args:
+        cv_df: CV results DataFrame from load_cv_results.
+        metric: Metric to summarise. Defaults to "f1" if present, otherwise
+            the first available metric.
+
+    Returns:
+        Dict mapping each param column name to a DataFrame with columns:
+        [param_value, mean_score, std_score, count].
+    """
+    metric = _resolve_metric(cv_df, metric)
+    score_col = f"mean_test_{metric}"
+    results = {}
+    for col in _param_cols(cv_df):
+        grouped = (
+            cv_df.assign(**{col: cv_df[col].astype(str)})
+            .groupby(col, dropna=False)[score_col]
+            .agg(mean_score="mean", std_score="std", count="count")
+            .reset_index()
+        )
+        grouped = grouped.rename(columns={col: "param_value"})
+        grouped = grouped.sort_values("mean_score", ascending=False).reset_index(drop=True)
+        results[col] = grouped
+    return results
+
+
+def plot_param_effects(
+    cv_df: pd.DataFrame,
+    metric: str | None = None,
+    figsize: tuple | None = None,
+) -> tuple:
+    """
+    Plot a grid of bar charts showing mean score (± std) for each value of
+    every param_* column.
+
+    Args:
+        cv_df: CV results DataFrame from load_cv_results.
+        metric: Metric to plot. Defaults to "f1" if present, otherwise the
+            first available metric. Pass "all" to plot all available metrics
+            as grouped bars within each subplot.
+        figsize: Optional (width, height) tuple. Auto-sized if None.
+
+    Returns:
+        (fig, axes) — call plt.show() or fig.savefig() in the caller.
+    """
+    if metric == "all":
+        return _plot_param_effects_all_metrics(cv_df, figsize=figsize)
+
+    metric = _resolve_metric(cv_df, metric)
+    effects = summarise_param_effects(cv_df, metric=metric)
+    n_params = len(effects)
+    if n_params == 0:
+        raise ValueError("No param_* columns found in cv_df.")
+
+    ncols = min(3, n_params)
+    nrows = math.ceil(n_params / ncols)
+
+    if figsize is None:
+        figsize = (5 * ncols, 4 * nrows)
+
+    fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
+    axes_flat = axes.flatten()
+
+    score_label = _score_display_name(metric)
+
+    for i, (col, grouped) in enumerate(effects.items()):
+        ax = axes_flat[i]
+        x = np.arange(len(grouped))
+        yerr = grouped["std_score"].fillna(0)
+        ax.bar(x, grouped["mean_score"], yerr=yerr, capsize=4, color="royalblue", alpha=0.8)
+        ax.set_xticks(x)
+        ax.set_xticklabels(grouped["param_value"].astype(str), rotation=30, ha="right")
+        ax.set_title(col.replace("param_", ""))
+        ax.set_ylabel(score_label)
+        ax.set_ylim(0, 1)
+
+    for j in range(i + 1, len(axes_flat)):
+        axes_flat[j].set_visible(False)
+
+    fig.suptitle(f"Mean {score_label} by parameter value", fontsize=13)
+    fig.tight_layout()
+    return fig, axes
+
+
+def _plot_param_effects_all_metrics(cv_df: pd.DataFrame, figsize: tuple | None = None) -> tuple:
+    """Grouped-bar variant of plot_param_effects with one bar group per metric."""
+    metrics = _detect_metrics(cv_df)
+    if not metrics:
+        raise ValueError("No mean_test_<metric> columns found in cv_df.")
+
+    # Build {metric: {param_col: grouped_df}} by reusing summarise_param_effects
+    effects_by_metric = {m: summarise_param_effects(cv_df, metric=m) for m in metrics}
+
+    param_cols = list(next(iter(effects_by_metric.values())).keys())
+    n_params = len(param_cols)
+    if n_params == 0:
+        raise ValueError("No param_* columns found in cv_df.")
+
+    ncols = min(3, n_params)
+    nrows = math.ceil(n_params / ncols)
+
+    if figsize is None:
+        figsize = (5 * ncols, 4 * nrows)
+
+    fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
+    axes_flat = axes.flatten()
+
+    n_metrics = len(metrics)
+    bar_width = 0.8 / n_metrics
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+
+    for i, col in enumerate(param_cols):
+        ax = axes_flat[i]
+        # Use param_value order from first metric's grouped df (sorted by mean score)
+        param_values = effects_by_metric[metrics[0]][col]["param_value"].tolist()
+        x = np.arange(len(param_values))
+
+        for m_idx, m in enumerate(metrics):
+            grouped = effects_by_metric[m][col].set_index("param_value").reindex(param_values)
+            offset = (m_idx - (n_metrics - 1) / 2) * bar_width
+            ax.bar(
+                x + offset,
+                grouped["mean_score"],
+                yerr=grouped["std_score"].fillna(0),
+                width=bar_width,
+                capsize=3,
+                color=colors[m_idx % len(colors)],
+                alpha=0.8,
+                label=m,
+            )
+
+        ax.set_xticks(x)
+        ax.set_xticklabels(param_values, rotation=30, ha="right")
+        ax.set_title(col.replace("param_", ""))
+        ax.set_ylabel("score")
+        ax.set_ylim(0, 1)
+        for level in [0.2, 0.4, 0.6, 0.8]:
+            ax.axhline(level, color="lightgrey", linestyle="--", linewidth=0.8, zorder=0)
+        if i == 0:
+            ax.legend(fontsize=7)
+
+    for j in range(i + 1, len(axes_flat)):
+        axes_flat[j].set_visible(False)
+
+    fig.suptitle("Mean scores by parameter value", fontsize=13)
+    fig.tight_layout()
+    return fig, axes
+
+
+def plot_score_heatmap(
+    cv_df: pd.DataFrame,
+    param_x: str,
+    param_y: str,
+    metric: str | None = None,
+    ax=None,
+) -> tuple:
+    """
+    Plot a 2D heatmap of mean score across two parameters.
+
+    Args:
+        cv_df: CV results DataFrame from load_cv_results.
+        param_x: Parameter for the x-axis. Can be given with or without the
+            'param_' prefix (e.g. 'max_depth' or 'param_max_depth').
+        param_y: Parameter for the y-axis.
+        metric: Metric to aggregate. Defaults to "f1" if present, otherwise
+            the first available metric.
+        ax: Optional matplotlib Axes to draw on. If None, a new figure is
+            created.
+
+    Returns:
+        (fig, ax) — call plt.show() or fig.savefig() in the caller. If an ax
+        was passed in, fig is the parent figure of that ax.
+    """
+    metric = _resolve_metric(cv_df, metric)
+    score_col = f"mean_test_{metric}"
+
+    def _full_col(name):
+        if name.startswith("param_"):
+            return name
+        candidate = f"param_{name}"
+        if candidate in cv_df.columns:
+            return candidate
+        raise ValueError(f"Column '{name}' or '{candidate}' not found in cv_df.")
+
+    col_x = _full_col(param_x)
+    col_y = _full_col(param_y)
+
+    pivot = cv_df.groupby([col_y, col_x])[score_col].mean().unstack()
+    pivot.index = pivot.index.astype(str)
+    pivot.columns = pivot.columns.astype(str)
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(max(4, len(pivot.columns) * 1.5), max(3, len(pivot) * 1.2)))
+    else:
+        fig = ax.get_figure()
+
+    im = ax.imshow(pivot.values, aspect="auto", cmap="YlGn", vmin=0, vmax=1)
+    plt.colorbar(im, ax=ax, label=_score_display_name(metric))
+
+    ax.set_xticks(range(len(pivot.columns)))
+    ax.set_xticklabels(pivot.columns, rotation=30, ha="right")
+    ax.set_yticks(range(len(pivot.index)))
+    ax.set_yticklabels(pivot.index)
+    ax.set_xlabel(col_x.replace("param_", ""))
+    ax.set_ylabel(col_y.replace("param_", ""))
+    ax.set_title(f"Mean {_score_display_name(metric)}")
+
+    for row_i in range(len(pivot.index)):
+        for col_j in range(len(pivot.columns)):
+            val = pivot.values[row_i, col_j]
+            if not np.isnan(val):
+                ax.text(col_j, row_i, f"{val:.3f}", ha="center", va="center", fontsize=9)
+
+    fig.tight_layout()
+    return fig, ax

--- a/ml_baselines/modelling/predict.py
+++ b/ml_baselines/modelling/predict.py
@@ -1,5 +1,8 @@
 import numpy as np
 import pandas as pd
+import joblib
+import glob
+from pathlib import Path
 
 from sklearn.metrics import precision_score, recall_score, f1_score
 
@@ -9,8 +12,31 @@ from ml_baselines.modelling.plot import plot_confusion_matrix, plot_obs, plot_ob
 from ml_baselines.config import Config
 cfg = Config()
 
+def load_baseline_model(site, model_type="mlp", models_folder=cfg.models_path, timestamp=None):
+    """
+    Load a trained model and its extra info from a specified folder. If timestamp is provided, it will look for a model file with that timestamp; otherwise, it will load the most recent model file for the given site and model type.
 
-def predict_baselines(site, model, time_shift_hours=[6], prediction_threshold=0.5, prediction_mode="validation", verbose=True, save_preds = False, return_proba=False):
+    Args:
+    site (str): The site for which to load the model.
+    model_type (str): The type of model to load (default is "mlp").
+    models_folder (str): The folder where models are stored (default is cfg.models_path).
+    timestamp (str, optional): The timestamp to look for in the model filename. If None, loads the most recent model.
+    
+    Returns:
+    model: The loaded model object.
+    extra_info: A dictionary containing extra information about the model (e.g., scores, scaler, model inputs).
+    """
+    model_path = Path(models_folder) / site / f"{model_type}_model_*.joblib"
+    if timestamp is not None:
+        model_path = model_path.with_name(f"{model_type}_model_{timestamp}.joblib")
+    model_file = glob.glob(str(model_path))
+    if not model_file:
+        raise FileNotFoundError(f"No model found at {model_path}")
+    model_dict = joblib.load(model_file[-1])  # Load the most recent model file
+    print(f"Loaded model from {model_file[-1]}")
+    return model_dict['model'], model_dict['extra_info']
+
+def predict_baselines(site, model, time_shift_hours=[6], prediction_threshold=0.5, prediction_mode="validation", scaler=None, verbose=True, save_preds = False, return_proba=False):
     """
     Predict baseline events for a given site using a trained model.
 
@@ -37,6 +63,9 @@ def predict_baselines(site, model, time_shift_hours=[6], prediction_threshold=0.
     if verbose: print(f"Predicting on {prediction_mode} set for site: {site} with prediction threshold: {prediction_threshold}")
 
     X, y = get_train_test_data(site, prediction_mode, time_shift_hours=time_shift_hours, verbose=verbose)    
+
+    if scaler is not None:
+        X = scaler.transform(X)
 
     y_pred = (model.predict_proba(X)[:, 1] >= prediction_threshold).astype(int)
     y_proba = model.predict_proba(X)[:, 1]

--- a/ml_baselines/modelling/predict.py
+++ b/ml_baselines/modelling/predict.py
@@ -12,7 +12,7 @@ from ml_baselines.modelling.plot import plot_confusion_matrix, plot_obs, plot_ob
 from ml_baselines.config import Config
 cfg = Config()
 
-def load_baseline_model(site, model_type="mlp", models_folder=cfg.models_path, timestamp=None):
+def load_baseline_model(site, model_type="mlp", models_folder=cfg.models_path, timestamp=None, suffix=None):
     """
     Load a trained model and its extra info from a specified folder. If timestamp is provided, it will look for a model file with that timestamp; otherwise, it will load the most recent model file for the given site and model type.
 
@@ -21,14 +21,19 @@ def load_baseline_model(site, model_type="mlp", models_folder=cfg.models_path, t
     model_type (str): The type of model to load (default is "mlp").
     models_folder (str): The folder where models are stored (default is cfg.models_path).
     timestamp (str, optional): The timestamp to look for in the model filename. If None, loads the most recent model.
-    
+    suffix (str, optional): A suffix to append to the model filename. Useful to identify files instead of relying on timestamps, or to distinguish between different versions of models trained at the same time.
     Returns:
     model: The loaded model object.
     extra_info: A dictionary containing extra information about the model (e.g., scores, scaler, model inputs).
     """
     model_path = Path(models_folder) / site / f"{model_type}_model_*.joblib"
-    if timestamp is not None:
-        model_path = model_path.with_name(f"{model_type}_model_{timestamp}.joblib")
+    if timestamp is not None and suffix is not None:
+        model_path = model_path.with_name(f"{model_type}_model_{timestamp}_{suffix}.joblib")
+    elif timestamp is not None:
+        model_path = model_path.with_name(f"{model_type}_model_{timestamp}*.joblib")
+    elif suffix is not None:
+        model_path = model_path.with_name(f"{model_type}_model_*{suffix}.joblib")
+        
     model_file = glob.glob(str(model_path))
     if not model_file:
         raise FileNotFoundError(f"No model found at {model_path}")

--- a/ml_baselines/modelling/predict.py
+++ b/ml_baselines/modelling/predict.py
@@ -34,7 +34,7 @@ def load_baseline_model(site, model_type="mlp", models_folder=cfg.models_path, t
     elif suffix is not None:
         model_path = model_path.with_name(f"{model_type}_model_*{suffix}.joblib")
         
-    model_file = glob.glob(str(model_path))
+    model_file = sorted(glob.glob(str(model_path)))
     if not model_file:
         raise FileNotFoundError(f"No model found at {model_path}")
     model_dict = joblib.load(model_file[-1])  # Load the most recent model file

--- a/ml_baselines/modelling/predict.py
+++ b/ml_baselines/modelling/predict.py
@@ -34,7 +34,7 @@ def load_baseline_model(site, model_type="mlp", models_folder=cfg.models_path, t
         raise FileNotFoundError(f"No model found at {model_path}")
     model_dict = joblib.load(model_file[-1])  # Load the most recent model file
     print(f"Loaded model from {model_file[-1]}")
-    return model_dict['model'], model_dict['extra_info']
+    return model_dict['model'], model_dict['info']
 
 def predict_baselines(site, model, time_shift_hours=[6], prediction_threshold=0.5, prediction_mode="validation", scaler=None, verbose=True, save_preds = False, return_proba=False):
     """

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -102,7 +102,7 @@ def get_train_test_data(site, test_train,
             # raise value error if df is now empty
             if df.shape[0] == 0:
                 raise ValueError(f"No data available for {site} in the test period after removing overlapping data with training and validation periods! Please check the periods specified in the config.")
-                
+
     # Drop any nan values
     df = df.dropna()
 
@@ -494,15 +494,15 @@ def train_baseline_model(site, model_type="mlp",
         print(f"Precision on Training Set = {precision_train:.3f}")
         if X_train_unbalanced is not None: print(f"Precision on the original Training Set = {precision_train_unbalanced:.3f}")
         print(f"Precision on Validation Set = {precision_val:.3f}")
-        print(f"Precision on Test Set = {precision_test:.3f}")
+        if evaluate_on_test: print(f"Precision on Test Set = {precision_test:.3f}")
         print(f"Recall on Training Set = {recall_train:.3f}")
         if X_train_unbalanced is not None: print(f"Recall on the original Training Set = {recall_train_unbalanced:.3f}")
         print(f"Recall on Validation Set = {recall_val:.3f}")
-        print(f"Recall on Test Set = {recall_test:.3f}")
+        if evaluate_on_test: print(f"Recall on Test Set = {recall_test:.3f}")
         print(f"F1 Score on Training Set = {f1_train:.3f}")
         if X_train_unbalanced is not None: print(f"F1 Score on the original Training Set = {f1_train_unbalanced:.3f}")
         print(f"F1 Score on Validation Set = {f1_val:.3f}")
-        print(f"F1 Score on Test Set = {f1_test:.3f}")
+        if evaluate_on_test: print(f"F1 Score on Test Set = {f1_test:.3f}")
 
     extra_info = {}
     

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -32,106 +32,7 @@ def get_train_test_data(site, test_train,
 
     Args:
         site (str): The site for which to get the data.
-        test_train (str): The type of data to get. Must be one of 'train', 'test', or 'validation'.
-        balance (bool): If True, balance the dataset by undersampling the majority class.
-            NOTE: This is only applied to training data (ignored for test or validation).
-        undersample (float or bool): If a float between 0 and 1, randomly undersample the dataset to this fraction.
-            NOTE: This is only applied to training data (ignored for test or validation).
-        time_shift_hours (list of int): List of time shifts in hours to create lagged features for. For example, [6, 24] will create features shifted by 6 and 24 hours.
-        return_dataframe (bool): If True, return the data as a DataFrame. If False, return the features and target separately.
-        balance_method (str): The method to use for balancing the dataset. Must be one of 'random' or 'deterministic'.
-        verbose (bool): If True, print verbose output.
-    Returns:
-        pd.DataFrame or tuple: If return_dataframe is True, returns a DataFrame with the features and target.
-                                If return_dataframe is False, returns a tuple (X, y) where X is the features and y is the target.
-
-    Raises:
-        ValueError: If the test_train argument is not one of 'train', 'test', or 'validation'.
-    """
-
-    if test_train == "train":
-        start_year = cfg.training_period[site][0]
-        end_year = cfg.training_period[site][1]
-    elif test_train == "test":
-        start_year = cfg.testing_period[site][0]
-        end_year = cfg.testing_period[site][1]
-    elif test_train == "validation":
-        start_year = cfg.validation_period[site][0]
-        end_year = cfg.validation_period[site][1]
-        # check if config has full_period attribute
-    elif test_train == "full" and cfg.full_period[site] is not None:
-        start_year = cfg.full_period[site][0]
-        end_year = cfg.full_period[site][1]
-    elif test_train == "full":
-        start_year = cfg.training_period[site][0]
-        end_year = cfg.testing_period[site][1]
-    else:
-        raise ValueError("test_train must be either 'train', 'test', 'validation', or 'full' (for a custom period from config, or for all datasets stacked)")
-    
-    if verbose: print(f"... loading {test_train} data for site: {site}, period: {start_year}-{end_year}")
-
-    df_features = open_features(site,
-                            start_year = start_year,
-                            end_year = end_year,
-                            time_shift_hours = time_shift_hours)
-    df_intem = read_intem(site,
-                        start_year = start_year,
-                        end_year = end_year)
-
-    # Merge features and intem data on time. The intem flags should be merged with the nearest features in time
-    df = df_intem.merge(df_features, how='left', left_index=True, right_index=True)
-    
-    # Drop any nan values
-    df = df.dropna()
-
-    if df.shape[0] == 0:
-        raise ValueError(f"No data available for {site} in the specified period.")
-
-    # Check if the data is continuous
-    if not df.index.is_monotonic_increasing:
-        raise ValueError(f"Data for {site} is not continuous in the specified period.")
-    if not df.index.is_unique:
-        raise ValueError(f"Data for {site} has duplicate timestamps in the specified period.")
-
-    # Balance the dataset if required FOR TRAINING DATA ONLY
-    if balance > 0. and test_train == "train":
-        if verbose: print(f"... balancing dataset to target baseline ratio of {balance}")
-        if balance > 1:
-            raise ValueError("Balance must be between 0 and 1.")
-        # If balance is True, balance the dataset
-        df = balance_dataset(df, target_baseline_ratio=balance, method=balance_method)
-
-    # Undersample the dataset if required FOR TRAINING DATA ONLY
-    if undersample and test_train == "train":
-        if verbose: print(f"... undersampling dataset to fraction {undersample}")
-        if not (0. < undersample <= 1.):
-            raise ValueError("Undersample must be a float between 0 and 1.")
-        # Randomly undersample the dataset
-        # First shuffle the DataFrame
-        df = df.sample(frac=1, random_state=42).reset_index(drop=True)
-        # Then, just keep the first "undersample" rows
-        df = df.iloc[:int(undersample*len(df))]
-
-    if return_dataframe:
-        return df
-    else:
-        # Split the data into features and target
-        X = df.drop(columns=["baseline"])
-        y = df["baseline"]
-        return X, y
-
-
-def get_train_test_data_updated(site, test_train,
-                        balance=-1,
-                        undersample=0,
-                        time_shift_hours=[6],
-                        return_dataframe=False,
-                        balance_method="random", verbose=True):
-    """ Get the training, testing or validation data for a given site.
-
-    Args:
-        site (str): The site for which to get the data.
-        test_train (str): The type of data to get. Must be one of 'train', 'test', or 'validation'.
+        test_train (str): The type of data to get. Must be one of 'train', 'test', 'validation' or 'full', which will return a custom period from the config, or all datasets stacked.
         balance (bool): If True, balance the dataset by undersampling the majority class.
             NOTE: This is only applied to training data (ignored for test or validation).
         undersample (float or bool): If a float between 0 and 1, randomly undersample the dataset to this fraction.
@@ -189,10 +90,14 @@ def get_train_test_data_updated(site, test_train,
 
     # if its test mode, make sure that there is no overlap with training and val, and if so remove from df
     if test_train == "test":
+        if verbose: print("")
         train_period = periods_dict["train"]
         val_period = periods_dict["validation"]
-        df = df[~((df.index.year >= train_period[0]) & (df.index.year <= train_period[1]))]
-        df = df[~((df.index.year >= val_period[0]) & (df.index.year <= val_period[1]))]
+        # first, let's check if there is overlap between either training or validation period and the test period, and if so print a warning
+        if ((val_period[0] <= end_year) and (val_period[1] >= start_year)) or ((train_period[0] <= end_year) and (train_period[1] >= start_year)):
+            if verbose: print(f"Warning: Test period {start_year}-{end_year} overlaps with validation or training periods {val_period[0]}-{val_period[1]} or {train_period[0]}-{train_period[1]}! Removing overlapping data from test set.")
+            df = df[~((df.index.year >= train_period[0]) & (df.index.year <= train_period[1]))]
+            df = df[~((df.index.year >= val_period[0]) & (df.index.year <= val_period[1]))]
     
     # Drop any nan values
     df = df.dropna()
@@ -613,7 +518,7 @@ def train_baseline_model(site, model_type="mlp",
         scores["precision_train_unbalanced"] = precision_train_unbalanced
         scores["recall_train_unbalanced"] = recall_train_unbalanced
         scores["f1_train_unbalanced"] = f1_train_unbalanced
-        
+
     if return_scores: 
         extra_info["scores"] = scores
     if return_scaler:

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -360,6 +360,7 @@ def train_baseline_model(site, model_type="mlp",
         return_scores (bool): Whether to return the evaluation scores as a dictionary.
         return_scaler (bool): Whether to return the fitted scaler used for normalising input features.
         verbose (bool): Whether to print verbose output.
+        evaluate_on_test (bool): Whether to evaluate the model on the test set after training. If False, test-set metrics will not be computed or reported. Defaults to True.
         save_model (bool): Whether to save the trained model.
         save_folder (str): The folder where the model should be saved. It will be saved in a subfolder named after the site, with a filename based on the model type and current timestamp.
         save_suffix (str, optional): A suffix to append to the saved model filename. If None, no suffix will be added.

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -1,4 +1,6 @@
 import itertools
+from pathlib import Path
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -319,7 +321,7 @@ def train_baseline_model(site, model_type="mlp",
             sample_weights=None,
             normalise_inputs=False,
             time_shift_hours=[6], prediction_threshold=0.5,
-            model_params=None, return_scores=False, return_scaler=False, verbose=True):
+            model_params=None, return_scores=False, return_scaler=False, verbose=True, save_model=False, save_folder=cfg.models_path):
     """ Train a model to classify baseline events for a given site.
 
     Args:
@@ -335,6 +337,8 @@ def train_baseline_model(site, model_type="mlp",
         return_scores (bool): Whether to return the evaluation scores as a dictionary.
         return_scaler (bool): Whether to return the fitted scaler used for normalising input features.
         verbose (bool): Whether to print verbose output.
+        save_model (bool): Whether to save the trained model.
+        save_folder (str): The folder where the model should be saved. It will be saved in a subfolder named after the site, with a filename based on the model type and current timestamp. 
     Returns:
         model: The trained model.
         X_train (pd.DataFrame): The feature matrix used for training.
@@ -443,8 +447,7 @@ def train_baseline_model(site, model_type="mlp",
 
     extra_info = {}
     
-    if return_scores: 
-        scores = {
+    scores = {
             "precision_train": precision_train,
             "precision_val": precision_val,
             "precision_test": precision_test,
@@ -455,9 +458,31 @@ def train_baseline_model(site, model_type="mlp",
             "f1_val": f1_val,
             "f1_test": f1_test
         }
+    if return_scores: 
         extra_info["scores"] = scores
     if return_scaler:
         extra_info["scaler"] = scaler
+
+    if save_model:
+        if save_folder is None:
+            print("Could not save the model! save_folder must be provided if save_model is True.")
+        else:
+            import joblib
+            # package up the model and extra info
+            # if scaler isnt returned save it anyway
+            
+            info_to_save = {"scores": scores, "scaler": scaler, "model_inputs": {"model_params": model_params, "balance": balance, "balance_method": balance_method, "undersample": undersample, "sample_weights": sample_weights, "normalise_inputs": normalise_inputs, "time_shift_hours": time_shift_hours, "prediction_threshold": prediction_threshold}}
+
+            to_save  = {
+                "model": model,
+                "info": info_to_save,
+            }
+
+            save_path = Path(save_folder) / site / f"{model_type}_model_{datetime.now().strftime('%Y-%m-%d_%H-%M')}.joblib"
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+
+            joblib.dump(to_save, save_path)
+            if verbose: print(f"Model saved to {save_path}")
     
     return model, X_train, y_train, extra_info
 
@@ -517,7 +542,7 @@ def train_baseline_model_grid_search(site,
                           param_grid=None,
                           data_kwargs=None,
                           validation_keys=None,
-                          return_cv_scores=False):
+                          return_cv_scores=False, save_cv_scores_folder=None):
     """ Train a model to classify baseline events using grid search for hyperparameter tuning.
 
     The grid search explores both the model hyperparameters in ``param_grid`` and
@@ -551,7 +576,7 @@ def train_baseline_model_grid_search(site,
             options such as ``"balance"`` or ``"undersample"`` should be
             omitted. If None, defaults to ``["time_shift_hours"]``.
         return_cv_scores (bool, optional): Whether to return the grid search results as a pandas dataset
-
+        save_cv_scores_folder (str, optional): The folder where to save the grid search results as a csv from the pandas dataset, if return_cv_scores is True. If None, the results will not be saved to a csv.
     Returns:
         tuple: ``(best_model, best_params, best_data_kwargs)`` — the fitted
             model, the winning hyperparameter dict, and the winning data-kwargs dict.
@@ -671,6 +696,11 @@ def train_baseline_model_grid_search(site,
             for key, value in eval(data_kw).items():
                 df[key] = str(value)
         all_cv_results = pd.concat(cv_results.values(), ignore_index=True)
+
+        if save_cv_scores_folder is not None:
+            save_path = Path(save_cv_scores_folder) / site 
+            save_path.mkdir(parents=True, exist_ok=True)
+            all_cv_results.to_csv(f"{save_cv_scores_folder}/cv_results_{site}_{model_type}.csv", index=False)
 
         return best_model, best_best_params, best_combo_kw, all_cv_results
     else:

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -543,7 +543,10 @@ def train_baseline_model_grid_search(site,
                           param_grid=None,
                           data_kwargs=None,
                           validation_keys=None,
-                          return_cv_scores=False, save_cv_scores_folder=None):
+                          return_cv_scores=False, 
+                          save_cv_scores=False,
+                          save_cv_scores_folder=cfg.models_path,
+                          save_suffix=None):
     """ Train a model to classify baseline events using grid search for hyperparameter tuning.
 
     The grid search explores both the model hyperparameters in ``param_grid`` and
@@ -698,10 +701,15 @@ def train_baseline_model_grid_search(site,
                 df[key] = str(value)
         all_cv_results = pd.concat(cv_results.values(), ignore_index=True)
 
-        if save_cv_scores_folder is not None:
-            save_path = Path(save_cv_scores_folder) / site 
-            save_path.mkdir(parents=True, exist_ok=True)
-            all_cv_results.to_csv(f"{save_cv_scores_folder}/cv_results_{site}_{model_type}.csv", index=False)
+        if save_cv_scores:
+            if save_cv_scores_folder is not None:
+                save_filename = f"cv_results_{site}_{model_type}_{save_suffix}.csv" if save_suffix is not None else f"cv_results_{site}_{model_type}.csv"
+                save_path = Path(save_cv_scores_folder) / site 
+                save_path.mkdir(parents=True, exist_ok=True)
+                all_cv_results.to_csv(save_filename, index=False)
+                print(f"CV scores saved to {save_path / save_filename}")
+            else:
+                print("Could not save CV scores! save_cv_scores_folder must be provided if save_cv_scores is True.")
 
         return best_model, best_best_params, best_combo_kw, all_cv_results
     else:

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -120,6 +120,119 @@ def get_train_test_data(site, test_train,
         return X, y
 
 
+def get_train_test_data_updated(site, test_train,
+                        balance=-1,
+                        undersample=0,
+                        time_shift_hours=[6],
+                        return_dataframe=False,
+                        balance_method="random", verbose=True):
+    """ Get the training, testing or validation data for a given site.
+
+    Args:
+        site (str): The site for which to get the data.
+        test_train (str): The type of data to get. Must be one of 'train', 'test', or 'validation'.
+        balance (bool): If True, balance the dataset by undersampling the majority class.
+            NOTE: This is only applied to training data (ignored for test or validation).
+        undersample (float or bool): If a float between 0 and 1, randomly undersample the dataset to this fraction.
+            NOTE: This is only applied to training data (ignored for test or validation).
+        time_shift_hours (list of int): List of time shifts in hours to create lagged features for. For example, [6, 24] will create features shifted by 6 and 24 hours.
+        return_dataframe (bool): If True, return the data as a DataFrame. If False, return the features and target separately.
+        balance_method (str): The method to use for balancing the dataset. Must be one of 'random' or 'deterministic'.
+        verbose (bool): If True, print verbose output.
+    Returns:
+        pd.DataFrame or tuple: If return_dataframe is True, returns a DataFrame with the features and target.
+                                If return_dataframe is False, returns a tuple (X, y) where X is the features and y is the target.
+
+    Raises:
+        ValueError: If the test_train argument is not one of 'train', 'test', or 'validation'.
+    """
+    ## let's make this into a dictionary where all of the attributes get collected
+    periods_dict = {}
+    periods_dict["train"] = cfg.training_period[site]
+    periods_dict["test"] = cfg.testing_period[site]
+    periods_dict["validation"] = cfg.validation_period[site]
+    if cfg.full_period[site] is not None:
+        periods_dict["full"] = cfg.full_period[site]
+    else:
+        # make it the min and max of all periods if full_period is not specified in the config
+        periods_dict["full"] = (min(cfg.training_period[site][0], cfg.testing_period[site][0], cfg.validation_period[site][0]),
+         max(cfg.training_period[site][1], cfg.testing_period[site][1], cfg.validation_period[site][1]))
+        
+    if test_train == "train":
+        start_year = periods_dict["train"][0]
+        end_year = periods_dict["train"][1]
+    elif test_train == "test":
+        start_year = periods_dict["test"][0]
+        end_year = periods_dict["test"][1]
+    elif test_train == "validation":
+        start_year = periods_dict["validation"][0]
+        end_year = periods_dict["validation"][1]
+    elif test_train == "full":
+        start_year = periods_dict["full"][0]
+        end_year = periods_dict["full"][1]
+    else:
+        raise ValueError("test_train must be either 'train', 'test', 'validation', or 'full' (for a custom period from config, or for all datasets stacked)")
+    
+    if verbose: print(f"... loading {test_train} data for site: {site}, period: {start_year}-{end_year}")
+
+    df_features = open_features(site,
+                            start_year = start_year,
+                            end_year = end_year,
+                            time_shift_hours = time_shift_hours)
+    df_intem = read_intem(site,
+                        start_year = start_year,
+                        end_year = end_year)
+
+    # Merge features and intem data on time. The intem flags should be merged with the nearest features in time
+    df = df_intem.merge(df_features, how='left', left_index=True, right_index=True)
+
+    # if its test mode, make sure that there is no overlap with training and val, and if so remove from df
+    if test_train == "test":
+        train_period = periods_dict["train"]
+        val_period = periods_dict["validation"]
+        df = df[~((df.index.year >= train_period[0]) & (df.index.year <= train_period[1]))]
+        df = df[~((df.index.year >= val_period[0]) & (df.index.year <= val_period[1]))]
+    
+    # Drop any nan values
+    df = df.dropna()
+
+    if df.shape[0] == 0:
+        raise ValueError(f"No data available for {site} in the specified period.")
+
+    # Check if the data is continuous
+    if not df.index.is_monotonic_increasing:
+        raise ValueError(f"Data for {site} is not continuous in the specified period.")
+    if not df.index.is_unique:
+        raise ValueError(f"Data for {site} has duplicate timestamps in the specified period.")
+
+    # Balance the dataset if required FOR TRAINING DATA ONLY
+    if balance > 0. and test_train == "train":
+        if verbose: print(f"... balancing dataset to target baseline ratio of {balance}")
+        if balance > 1:
+            raise ValueError("Balance must be between 0 and 1.")
+        # If balance is True, balance the dataset
+        df = balance_dataset(df, target_baseline_ratio=balance, method=balance_method)
+
+    # Undersample the dataset if required FOR TRAINING DATA ONLY
+    if undersample and test_train == "train":
+        if verbose: print(f"... undersampling dataset to fraction {undersample}")
+        if not (0. < undersample <= 1.):
+            raise ValueError("Undersample must be a float between 0 and 1.")
+        # Randomly undersample the dataset
+        # First shuffle the DataFrame
+        df = df.sample(frac=1, random_state=42).reset_index(drop=True)
+        # Then, just keep the first "undersample" rows
+        df = df.iloc[:int(undersample*len(df))]
+
+    if return_dataframe:
+        return df
+    else:
+        # Split the data into features and target
+        X = df.drop(columns=["baseline"])
+        y = df["baseline"]
+        return X, y
+
+
 def balance_dataset(df, target_baseline_ratio=0.5, method="random"):
     """ Balance the dataset by undersampling the majority class (baseline or non-baseline) to achieve a target ratio.
     
@@ -698,7 +811,7 @@ def train_baseline_model_grid_search(site,
         for data_kw, df in cv_results.items():
             df["data_kwarg"] = data_kw
             for key, value in eval(data_kw).items():
-                df[key] = str(value)
+                df[f"param_data_{key}"] = str(value)
         all_cv_results = pd.concat(cv_results.values(), ignore_index=True)
 
         if save_cv_scores:
@@ -706,7 +819,7 @@ def train_baseline_model_grid_search(site,
                 save_filename = f"cv_results_{site}_{model_type}_{save_suffix}.csv" if save_suffix is not None else f"cv_results_{site}_{model_type}.csv"
                 save_path = Path(save_cv_scores_folder) / site 
                 save_path.mkdir(parents=True, exist_ok=True)
-                all_cv_results.to_csv(save_filename, index=False)
+                all_cv_results.to_csv(save_path / save_filename, index=False)
                 print(f"CV scores saved to {save_path / save_filename}")
             else:
                 print("Could not save CV scores! save_cv_scores_folder must be provided if save_cv_scores is True.")

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -1,6 +1,7 @@
 import itertools
 from pathlib import Path
 from datetime import datetime
+import joblib
 
 import numpy as np
 import pandas as pd
@@ -434,7 +435,7 @@ def train_baseline_model(site, model_type="mlp",
             sample_weights=None,
             normalise_inputs=False,
             time_shift_hours=[6], prediction_threshold=0.5,
-            model_params=None, return_scores=False, return_scaler=False, verbose=True, save_model=False, save_folder=cfg.models_path, save_suffix=None):
+            model_params=None, return_scores=False, return_scaler=False, verbose=True, save_model=False, save_folder=cfg.models_path, save_suffix=None, evaluate_on_test=True, random_seed=42):
     """ Train a model to classify baseline events for a given site.
 
     Args:
@@ -453,6 +454,7 @@ def train_baseline_model(site, model_type="mlp",
         save_model (bool): Whether to save the trained model.
         save_folder (str): The folder where the model should be saved. It will be saved in a subfolder named after the site, with a filename based on the model type and current timestamp.
         save_suffix (str, optional): A suffix to append to the saved model filename. If None, no suffix will be added.
+        random_seed (int): The random seed to use for reproducible results.
     Returns:
         model: The trained model.
         X_train (pd.DataFrame): The feature matrix used for training.
@@ -464,6 +466,12 @@ def train_baseline_model(site, model_type="mlp",
     if verbose: print(f"Training {model_type.upper() if model_type == 'mlp' else model_type} model for site: {site}")
     X_train, y_train = get_train_test_data(site, "train", balance=balance, balance_method=balance_method,
                                time_shift_hours=time_shift_hours, undersample=undersample, verbose=verbose)
+    
+    if balance > 0 or undersample > 0:
+        X_train_unbalanced, y_train_unbalanced = get_train_test_data(site, "train", balance=-1, balance_method=balance_method, time_shift_hours=time_shift_hours, undersample=0, verbose=verbose)
+    else:
+        X_train_unbalanced, y_train_unbalanced = None, None
+
     
     if sample_weights is not None:
         if verbose: print("... calculating sample weights")
@@ -482,25 +490,30 @@ def train_baseline_model(site, model_type="mlp",
     if model_type not in valid_model_types:
         raise ValueError(f"Unknown model type: {model_type}! must be one of {valid_model_types}.")
     if model_type == "mlp":
-        model = MLPClassifier(**model_params, random_state=42)
+        model = MLPClassifier(**model_params, random_state=random_seed)
     elif model_type == "random_forest":
-        model = RandomForestClassifier(**model_params, random_state=42)
+        model = RandomForestClassifier(**model_params, random_state=random_seed)
     elif model_type == "gradient_boosting":
-        model = GradientBoostingClassifier(**model_params, random_state=42)
+        model = GradientBoostingClassifier(**model_params, random_state=random_seed)
     
     # Get the validation and testing data
     X_val, y_val = get_train_test_data(site, "validation",
                                        time_shift_hours=time_shift_hours, verbose=verbose)
-    #TODO: Testing on unbalanced data?
-    X_test, y_test = get_train_test_data(site, "test",
+    if evaluate_on_test:
+        X_test, y_test = get_train_test_data(site, "test",
                                          time_shift_hours=time_shift_hours, verbose=verbose)
+
 
     if normalise_inputs:
         if verbose: print("... normalising inputs")
         scaler = InputPerVariableScaler()
         X_train = scaler.fit_transform(X_train)
         X_val = scaler.transform(X_val)
-        X_test = scaler.transform(X_test)
+        if evaluate_on_test:
+            X_test = scaler.transform(X_test)
+        if X_train_unbalanced is not None:
+            X_train_unbalanced = scaler.transform(X_train_unbalanced)
+
     else:
         scaler = None
 
@@ -517,7 +530,10 @@ def train_baseline_model(site, model_type="mlp",
         if verbose: print(f"Using custom prediction threshold of {prediction_threshold} instead of default 0.5")
     y_pred_val = (model.predict_proba(X_val)[:, 1] >= prediction_threshold).astype(int)
     y_pred_train = (model.predict_proba(X_train)[:, 1] >= prediction_threshold).astype(int)
-    y_pred_test = (model.predict_proba(X_test)[:, 1] >= prediction_threshold).astype(int)
+    if evaluate_on_test:
+        y_pred_test = (model.predict_proba(X_test)[:, 1] >= prediction_threshold).astype(int)
+    if X_train_unbalanced is not None:
+        y_pred_train_unbalanced = (model.predict_proba(X_train_unbalanced)[:, 1] >= prediction_threshold).astype(int)
 
     # calculating scores
     # run each set of tests only if there are positive examples, otherwise return zero
@@ -539,23 +555,43 @@ def train_baseline_model(site, model_type="mlp",
         recall_train = recall_score(y_train, y_pred_train)
         f1_train = f1_score(y_train, y_pred_train)
 
-    if sum(y_pred_test) == 0:
-        precision_test = 0.0
-        recall_test = 0.0
-        f1_test = 0.0
+    if evaluate_on_test:
+        if sum(y_pred_test) == 0:
+            precision_test = 0.0
+            recall_test = 0.0
+            f1_test = 0.0
+        else:
+            precision_test = precision_score(y_test, y_pred_test)
+            recall_test = recall_score(y_test, y_pred_test)
+            f1_test = f1_score(y_test, y_pred_test)
     else:
-        precision_test = precision_score(y_test, y_pred_test)
-        recall_test = recall_score(y_test, y_pred_test)
-        f1_test = f1_score(y_test, y_pred_test)
+        precision_test = None
+        recall_test = None
+        f1_test = None
+    
+    if X_train_unbalanced is not None:
+        if sum(y_pred_train_unbalanced) == 0:
+            precision_train_unbalanced = 0.0
+            recall_train_unbalanced = 0.0
+            f1_train_unbalanced = 0.0
+        else:
+            precision_train_unbalanced = precision_score(y_train_unbalanced, y_pred_train_unbalanced)
+            recall_train_unbalanced = recall_score(y_train_unbalanced, y_pred_train_unbalanced)
+            f1_train_unbalanced = f1_score(y_train_unbalanced, y_pred_train_unbalanced)
 
     if verbose:
+        print("Evaluation scores:")
+        if X_train_unbalanced is not None: print("The training dataset was balanced or undersampled. Providing scores also on the original unbalanced training set")
         print(f"Precision on Training Set = {precision_train:.3f}")
+        if X_train_unbalanced is not None: print(f"Precision on the original Training Set = {precision_train_unbalanced:.3f}")
         print(f"Precision on Validation Set = {precision_val:.3f}")
         print(f"Precision on Test Set = {precision_test:.3f}")
         print(f"Recall on Training Set = {recall_train:.3f}")
+        if X_train_unbalanced is not None: print(f"Recall on the original Training Set = {recall_train_unbalanced:.3f}")
         print(f"Recall on Validation Set = {recall_val:.3f}")
         print(f"Recall on Test Set = {recall_test:.3f}")
         print(f"F1 Score on Training Set = {f1_train:.3f}")
+        if X_train_unbalanced is not None: print(f"F1 Score on the original Training Set = {f1_train_unbalanced:.3f}")
         print(f"F1 Score on Validation Set = {f1_val:.3f}")
         print(f"F1 Score on Test Set = {f1_test:.3f}")
 
@@ -572,16 +608,23 @@ def train_baseline_model(site, model_type="mlp",
             "f1_val": f1_val,
             "f1_test": f1_test
         }
+    
+    if X_train_unbalanced is not None:
+        scores["precision_train_unbalanced"] = precision_train_unbalanced
+        scores["recall_train_unbalanced"] = recall_train_unbalanced
+        scores["f1_train_unbalanced"] = f1_train_unbalanced
+        
     if return_scores: 
         extra_info["scores"] = scores
     if return_scaler:
         extra_info["scaler"] = scaler
 
+
+
     if save_model:
         if save_folder is None:
             print("Could not save the model! save_folder must be provided if save_model is True.")
         else:
-            import joblib
             # package up the model and extra info
             # if scaler isnt returned save it anyway
             
@@ -676,15 +719,18 @@ def train_baseline_model_grid_search(site,
         data_kwargs (dict, optional): A dictionary where each key is a keyword
             argument accepted by :func:`get_train_test_data` and each value is a
             list of options to explore. All combinations of options are tried.
+            The special key ``sample_weights`` is also supported and controls
+            class weighting during model fitting (not data loading).
             For example::
 
                 {
                     "balance": [-1, 0.5],
                     "time_shift_hours": [[6], [6, 24]],
+                    "sample_weights": [None, "auto", 2.0],
                 }
 
             Valid keys are ``balance``, ``undersample``, ``time_shift_hours``,
-            and ``balance_method``. If None, defaults to
+            ``balance_method``, and ``sample_weights``. If None, defaults to
             ``{"balance": [-1], "time_shift_hours": [[6]]}``.
         validation_keys (list of str, optional): Keys from ``data_kwargs`` that
             should also be forwarded when loading the validation set. Only
@@ -722,6 +768,14 @@ def train_baseline_model_grid_search(site,
     if validation_keys is None:
         validation_keys = ["time_shift_hours"]
 
+    valid_data_kwargs = {"balance", "undersample", "time_shift_hours", "balance_method", "sample_weights"}
+    unknown_keys = set(data_kwargs.keys()) - valid_data_kwargs
+    if unknown_keys:
+        raise ValueError(
+            f"Unknown data_kwargs keys: {sorted(unknown_keys)}. "
+            f"Valid keys are {sorted(valid_data_kwargs)}."
+        )
+
     # Build the cartesian product of all data-kwarg options
     keys = list(data_kwargs.keys())
     combos = list(itertools.product(*[data_kwargs[k] for k in keys]))
@@ -740,8 +794,11 @@ def train_baseline_model_grid_search(site,
         combo_kw = dict(zip(keys, combo))
         print(f"... data kwargs: {combo_kw}")
 
-        val_kw = {k: combo_kw[k] for k in validation_keys if k in combo_kw}
-        X_train, y_train = get_train_test_data(site, "train", **combo_kw)
+        sample_weight_setting = combo_kw.get("sample_weights", None)
+        data_loading_kw = {k: v for k, v in combo_kw.items() if k != "sample_weights"}
+
+        val_kw = {k: data_loading_kw[k] for k in validation_keys if k in data_loading_kw}
+        X_train, y_train = get_train_test_data(site, "train", **data_loading_kw)
         X_val, y_val = get_train_test_data(site, "validation", **val_kw)
 
         assert set(X_train.columns) == set(X_val.columns), "Feature columns in training and validation sets do not match. Check that the data kwargs affecting features are included in validation_keys."
@@ -765,7 +822,20 @@ def train_baseline_model_grid_search(site,
             )
 
         print(f"Training {model_type.upper() if model_type == 'mlp' else model_type} model for site: {site} with grid search...")
-        grid_search.fit(X_all, y_all)
+        if sample_weight_setting is not None:
+            train_weights = generate_sample_weights(
+                y_train,
+                baseline_weight=sample_weight_setting,
+                non_baseline_weight=1.0,
+                verbose=False,
+            )
+            # Validation rows are not used for fitting in PredefinedSplit,
+            # but provide unit weights so sample_weight has full-length shape.
+            val_weights = pd.Series(np.ones(len(y_val), dtype=float), index=y_val.index)
+            sample_weight_all = pd.concat([train_weights, val_weights]).to_numpy()
+            grid_search.fit(X_all, y_all, sample_weight=sample_weight_all)
+        else:
+            grid_search.fit(X_all, y_all)
 
         print("Best parameters found: ", grid_search.best_params_)
         print("Best score: ", grid_search.best_score_)
@@ -786,11 +856,22 @@ def train_baseline_model_grid_search(site,
 
     # Train final model with the winning combination
     best_val_kw = {k: best_combo_kw[k] for k in validation_keys if k in best_combo_kw}
-    X_train_final, y_train_final = get_train_test_data(site, "train", **best_combo_kw)
+    best_data_loading_kw = {k: v for k, v in best_combo_kw.items() if k != "sample_weights"}
+    X_train_final, y_train_final = get_train_test_data(site, "train", **best_data_loading_kw)
     X_val_final, y_val_final = get_train_test_data(site, "validation", **best_val_kw)
 
     best_model = model.__class__(random_state=42, **best_best_params)
-    best_model.fit(X_train_final, y_train_final)
+    best_sample_weight_setting = best_combo_kw.get("sample_weights", None)
+    if best_sample_weight_setting is not None:
+        final_train_weights = generate_sample_weights(
+            y_train_final,
+            baseline_weight=best_sample_weight_setting,
+            non_baseline_weight=1.0,
+            verbose=False,
+        )
+        best_model.fit(X_train_final, y_train_final, sample_weight=final_train_weights)
+    else:
+        best_model.fit(X_train_final, y_train_final)
 
     # Evaluate on validation set
     pred_val = best_model.predict(X_val_final)

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -98,7 +98,11 @@ def get_train_test_data(site, test_train,
             if verbose: print(f"Warning: Test period {start_year}-{end_year} overlaps with validation or training periods {val_period[0]}-{val_period[1]} or {train_period[0]}-{train_period[1]}! Removing overlapping data from test set.")
             df = df[~((df.index.year >= train_period[0]) & (df.index.year <= train_period[1]))]
             df = df[~((df.index.year >= val_period[0]) & (df.index.year <= val_period[1]))]
-    
+
+            # raise value error if df is now empty
+            if df.shape[0] == 0:
+                raise ValueError(f"No data available for {site} in the test period after removing overlapping data with training and validation periods! Please check the periods specified in the config.")
+                
     # Drop any nan values
     df = df.dropna()
 

--- a/ml_baselines/modelling/train.py
+++ b/ml_baselines/modelling/train.py
@@ -321,7 +321,7 @@ def train_baseline_model(site, model_type="mlp",
             sample_weights=None,
             normalise_inputs=False,
             time_shift_hours=[6], prediction_threshold=0.5,
-            model_params=None, return_scores=False, return_scaler=False, verbose=True, save_model=False, save_folder=cfg.models_path):
+            model_params=None, return_scores=False, return_scaler=False, verbose=True, save_model=False, save_folder=cfg.models_path, save_suffix=None):
     """ Train a model to classify baseline events for a given site.
 
     Args:
@@ -338,7 +338,8 @@ def train_baseline_model(site, model_type="mlp",
         return_scaler (bool): Whether to return the fitted scaler used for normalising input features.
         verbose (bool): Whether to print verbose output.
         save_model (bool): Whether to save the trained model.
-        save_folder (str): The folder where the model should be saved. It will be saved in a subfolder named after the site, with a filename based on the model type and current timestamp. 
+        save_folder (str): The folder where the model should be saved. It will be saved in a subfolder named after the site, with a filename based on the model type and current timestamp.
+        save_suffix (str, optional): A suffix to append to the saved model filename. If None, no suffix will be added.
     Returns:
         model: The trained model.
         X_train (pd.DataFrame): The feature matrix used for training.
@@ -478,7 +479,7 @@ def train_baseline_model(site, model_type="mlp",
                 "info": info_to_save,
             }
 
-            save_path = Path(save_folder) / site / f"{model_type}_model_{datetime.now().strftime('%Y-%m-%d_%H-%M')}.joblib"
+            save_path = Path(save_folder) / site / f"{model_type}_model_{datetime.now().strftime('%Y-%m-%d_%H-%M')}{f'_{save_suffix}' if save_suffix is not None else ''}.joblib"
             save_path.parent.mkdir(parents=True, exist_ok=True)
 
             joblib.dump(to_save, save_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ pandas
 scikit-learn>=1.7
 numpy
 xarray
+dask
 cdsapi
 netcdf4
+matplotlib

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -34,6 +34,46 @@ class DummyClassifier:
         return (self.predict_proba(X)[:, 1] >= 0.5).astype(int)
 
 
+class DummyGridSearchCV:
+    instances = []
+
+    def __init__(self, estimator, param_grid, scoring=None, cv=None, refit=True, verbose=0, n_jobs=None, return_train_score=False):
+        self.estimator = estimator
+        self.param_grid = param_grid
+        self.scoring = scoring
+        self.cv = cv
+        self.refit = refit
+        self.verbose = verbose
+        self.n_jobs = n_jobs
+        self.return_train_score = return_train_score
+
+        self.fit_X = None
+        self.fit_y = None
+        self.fit_sample_weight = None
+        self.best_params_ = None
+        self.best_score_ = None
+        self.cv_results_ = None
+
+        DummyGridSearchCV.instances.append(self)
+
+    def fit(self, X, y, sample_weight=None):
+        self.fit_X = X.copy()
+        self.fit_y = y.copy()
+        self.fit_sample_weight = None if sample_weight is None else np.array(sample_weight, copy=True)
+
+        self.best_params_ = {
+            key: (value[0] if isinstance(value, list) else value)
+            for key, value in self.param_grid.items()
+        }
+        self.best_score_ = 0.0 if sample_weight is None else float(np.mean(sample_weight))
+        self.cv_results_ = {
+            "mean_test_score": np.array([self.best_score_]),
+            "rank_test_score": np.array([1]),
+            "params": [self.best_params_],
+        }
+        return self
+
+
 @pytest.fixture
 def patched_training_data(monkeypatch):
     def make_frame(baseline_values):
@@ -70,6 +110,49 @@ def patched_training_data(monkeypatch):
     monkeypatch.setattr(train_module, "MLPClassifier", DummyClassifier)
     monkeypatch.setattr(train_module, "RandomForestClassifier", DummyClassifier)
     monkeypatch.setattr(train_module, "GradientBoostingClassifier", DummyClassifier)
+
+
+@pytest.fixture
+def patched_grid_search_setup(monkeypatch):
+    DummyGridSearchCV.instances = []
+    get_data_calls = []
+
+    train_df = pd.DataFrame(
+        {
+            "baseline": [1, 0, 1, 0],
+            "u10_0": [1.0, 2.0, 3.0, 4.0],
+            "v10_0": [10.0, 11.0, 12.0, 13.0],
+        },
+        index=pd.date_range("2020-01-01", periods=4, freq="h"),
+    )
+    val_df = pd.DataFrame(
+        {
+            "baseline": [1, 0],
+            "u10_0": [5.0, 6.0],
+            "v10_0": [14.0, 15.0],
+        },
+        index=pd.date_range("2020-01-05", periods=2, freq="h"),
+    )
+
+    def fake_get_train_test_data(site, test_train, **kwargs):
+        get_data_calls.append((test_train, kwargs.copy()))
+        if test_train == "train":
+            df = train_df
+        elif test_train == "validation":
+            df = val_df
+        else:
+            raise AssertionError(f"Unexpected split requested in grid-search test: {test_train}")
+        return df.drop(columns=["baseline"]), df["baseline"]
+
+    monkeypatch.setattr(train_module, "get_train_test_data", fake_get_train_test_data)
+    monkeypatch.setattr(train_module, "GridSearchCV", DummyGridSearchCV)
+    monkeypatch.setattr(train_module, "MLPClassifier", DummyClassifier)
+
+    return {
+        "calls": get_data_calls,
+        "train_index": train_df.index,
+        "val_index": val_df.index,
+    }
 
 
 class TestTrainBaselineModel:
@@ -227,6 +310,40 @@ def test_balance_dataset():
     assert np.isclose(baseline_count / (baseline_count + non_baseline_count), 0.8, atol=0.01), "Baseline ratio is not 0.8"
     assert np.isclose(non_baseline_count / (baseline_count + non_baseline_count), 0.2, atol=0.01), "Non-baseline ratio is not 0.2"
 
+def test_get_train_test_data_removes_overlap_from_test_split(monkeypatch):
+    site = "dummy-site"
+
+    monkeypatch.setattr(train_module.cfg, "training_period", {site: (2019, 2019)}, raising=False)
+    monkeypatch.setattr(train_module.cfg, "validation_period", {site: (2020, 2020)}, raising=False)
+    monkeypatch.setattr(train_module.cfg, "testing_period", {site: (2019, 2021)}, raising=False)
+    monkeypatch.setattr(train_module.cfg, "full_period", {site: None}, raising=False)
+
+    idx = pd.to_datetime(
+        [
+            "2019-01-01 00:00", "2019-06-01 00:00",
+            "2020-01-01 00:00", "2020-06-01 00:00",
+            "2021-01-01 00:00", "2021-06-01 00:00",
+        ]
+    )
+
+    df_features = pd.DataFrame(
+        {
+            "u10_0": np.arange(len(idx), dtype=float),
+            "v10_0": np.arange(len(idx), dtype=float) + 10.0,
+        },
+        index=idx,
+    )
+    df_intem = pd.DataFrame({"baseline": [0, 1, 0, 1, 0, 1]}, index=idx)
+
+    monkeypatch.setattr(train_module, "open_features", lambda *args, **kwargs: df_features)
+    monkeypatch.setattr(train_module, "read_intem", lambda *args, **kwargs: df_intem)
+
+    X_test, y_test = train_module.get_train_test_data(site, "test", verbose=False)
+
+    assert set(X_test.index.year) == {2021}
+    assert len(X_test) == 2
+    assert len(y_test) == 2
+
 class TestInputPerVariableScaler:
     def test_fit_transform_dataframe(self):
         # Goal: verify grouped dataframe features are standardized and columns are preserved.
@@ -361,6 +478,78 @@ class TestInputPerVariableScaler:
 
         assert list(transformed.columns) == list(test_df.columns)
         assert np.allclose(transformed.values, expected.values, atol=1e-12)
+
+
+class TestTrainBaselineModelGridSearch:
+    def test_grid_search_passes_sample_weights_to_cv_fit(self, patched_grid_search_setup):
+        train_module.train_baseline_model_grid_search(
+            site="dummy-site",
+            model_type="mlp",
+            param_grid={"alpha": [0.1]},
+            data_kwargs={"time_shift_hours": [[6]], "sample_weights": [None, 3.0]},
+            validation_keys=["time_shift_hours"],
+        )
+
+        assert len(DummyGridSearchCV.instances) == 2
+        weighted_fit = [inst for inst in DummyGridSearchCV.instances if inst.fit_sample_weight is not None]
+        assert len(weighted_fit) == 1
+
+        sample_weight = weighted_fit[0].fit_sample_weight
+        assert len(sample_weight) == 6
+        assert np.allclose(sample_weight, np.array([3.0, 1.0, 3.0, 1.0, 1.0, 1.0]))
+
+    def test_grid_search_does_not_forward_sample_weights_to_data_loader(self, patched_grid_search_setup):
+        train_module.train_baseline_model_grid_search(
+            site="dummy-site",
+            model_type="mlp",
+            param_grid={"alpha": [0.1]},
+            data_kwargs={"time_shift_hours": [[6]], "sample_weights": [None, 2.0]},
+            validation_keys=["time_shift_hours"],
+        )
+
+        for _, kwargs in patched_grid_search_setup["calls"]:
+            assert "sample_weights" not in kwargs
+
+    def test_grid_search_rejects_unknown_data_kwargs_key(self, patched_grid_search_setup):
+        with pytest.raises(ValueError, match="Unknown data_kwargs keys"):
+            train_module.train_baseline_model_grid_search(
+                site="dummy-site",
+                model_type="mlp",
+                param_grid={"alpha": [0.1]},
+                data_kwargs={"time_shift_hours": [[6]], "bad_key": [123]},
+            )
+
+    def test_grid_search_uses_winning_sample_weights_in_final_fit(self, patched_grid_search_setup):
+        best_model, _, best_combo_kw = train_module.train_baseline_model_grid_search(
+            site="dummy-site",
+            model_type="mlp",
+            param_grid={"alpha": [0.1]},
+            data_kwargs={"time_shift_hours": [[6]], "sample_weights": [None, 3.0]},
+            validation_keys=["time_shift_hours"],
+        )
+
+        assert isinstance(best_model, DummyClassifier)
+        assert best_combo_kw["sample_weights"] == 3.0
+        assert best_model.fit_sample_weight is not None
+
+        expected_weights = pd.Series([3.0, 1.0, 3.0, 1.0], index=patched_grid_search_setup["train_index"])
+        pd.testing.assert_series_equal(best_model.fit_sample_weight, expected_weights)
+
+    def test_grid_search_returns_cv_scores_with_data_kwarg_metadata(self, patched_grid_search_setup):
+        _, _, best_combo_kw, all_cv_results = train_module.train_baseline_model_grid_search(
+            site="dummy-site",
+            model_type="mlp",
+            param_grid={"alpha": [0.1]},
+            data_kwargs={"balance": [-1], "time_shift_hours": [[6]], "sample_weights": [None, 2.0]},
+            validation_keys=["time_shift_hours"],
+            return_cv_scores=True,
+        )
+
+        assert "sample_weights" in best_combo_kw
+        assert "data_kwarg" in all_cv_results.columns
+        assert "param_data_sample_weights" in all_cv_results.columns
+        assert "param_data_balance" in all_cv_results.columns
+        assert set(all_cv_results["param_data_sample_weights"].unique()) == {"None", "2.0"}
 
 
 ## TODO add tests checking it works within the pipeline after file merging with main branch


### PR DESCRIPTION
Added the following capabilities:

-  Saving a model during training, and loading it to make predictions
```python
train_baseline_model("MHD", model_type="mlp", ......, save_model=True, save_folder=cfg.models_path, save_suffix="example_run")
```
will save the model to `path/ml-baselines/models/MHD/mlp_model_2026-04-07_13-58_example_run.joblib`, which then can be loaded 
```python
model, extra_info = load_baseline_model("MHD", "mlp", suffix="example_run")
scaler, time_shift_hours = extra_info["scaler"], extra_info["model_inputs"]["time_shift_hours"]
# use the model to predict
y, y_pred, scores  = predict_baselines(site="MHD",  model=model, time_shift_hours=time_shift_hours, scaler=scaler)
```
- Saving the scores of a grid search
```python
train_baseline_model_grid_search(model_type="gradient_boosting", .... return_cv_scores=True, save_cv_scores=True,  save_suffix="test_run")
````
will save the scores as a csv to `path/ml-baselines/models/MHD/cv_results_MHD_gradient_boosting_test_run.csv`, which can then be loaded and inspected
```python
from ml_baselines.modelling.cv_analysis import load_cv_results, get_top_params, plot_param_effects, plot_score_heatmap
df = load_cv_results(site="MHD", save_suffix="test_run", model_type="gradient_boosting")
# print the parameters for the best three models in terms of precision
best_precision_params = get_best_params(df, n=3, metric="precision")
print(best_precision_params)
# plot how the scores change for each parameter (see the plot below)
fig, axes = plot_param_effects(df, metric="all")
plt.show()
```
- Other improvements:
    - `train_baseline_model` now only evaluates on the test set if `evaluate_on_test=True`
    - if balancing or resampling the training dataset with `train_baseline_model`, it will also output the scores on the original training dataset (so that the results are comparable to the validation/test set)
    - `get_train_test_data` now works as expected with test periods that overlap with train/validation periods - the overlapping periods get removed
    - `train_baseline_model_grid_search` now also evaluates different sample_weights, passed through the `data_kwargs` for example `data_kwargs = {"time_shift_hours":[[6], [6,12]], "sample_weights":[None, 2, 5]}`

Example output of plot_param_effects:
<img width="1489" height="1572" alt="image" src="https://github.com/user-attachments/assets/8f0d0439-5849-4529-9047-135682d43045" />
